### PR TITLE
Fix charset for some language, kr and jp is unchecked, possible still…

### DIFF
--- a/src/main/java/com/aembr/guesstheutils/utils/FileUtils.java
+++ b/src/main/java/com/aembr/guesstheutils/utils/FileUtils.java
@@ -5,6 +5,7 @@ import com.aembr.guesstheutils.config.GuessTheUtilsConfig;
 import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
 public class FileUtils {
@@ -28,7 +29,7 @@ public class FileUtils {
             throw new IOException("Failed to download file: " + fileUrl);
         }
 
-        try (BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream(), StandardCharSets.UTF_8));
              StringWriter writer = new StringWriter()) {
             String line;
             while ((line = in.readLine()) != null) {

--- a/src/main/java/com/aembr/guesstheutils/utils/FileUtils.java
+++ b/src/main/java/com/aembr/guesstheutils/utils/FileUtils.java
@@ -29,7 +29,7 @@ public class FileUtils {
             throw new IOException("Failed to download file: " + fileUrl);
         }
 
-        try (BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream(), StandardCharSets.UTF_8));
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
              StringWriter writer = new StringWriter()) {
             String line;
             while ((line = in.readLine()) != null) {

--- a/src/main/java/com/aembr/guesstheutils/utils/TranslationData.java
+++ b/src/main/java/com/aembr/guesstheutils/utils/TranslationData.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.*;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
@@ -56,7 +57,7 @@ public class TranslationData {
         Gson gson = new Gson();
         Type translationDataType = new TypeToken<List<TranslationDataEntry>>() {}.getType();
 
-        try (FileReader reader = new FileReader(configFile)) {
+        try (FileReader reader = new FileReader(configFile, StandardCharSets.UTF_8)) {
             return gson.fromJson(reader, translationDataType);
         } catch (IOException e) {
             GuessTheUtils.LOGGER.error(e.getMessage());

--- a/src/main/java/com/aembr/guesstheutils/utils/TranslationData.java
+++ b/src/main/java/com/aembr/guesstheutils/utils/TranslationData.java
@@ -57,7 +57,7 @@ public class TranslationData {
         Gson gson = new Gson();
         Type translationDataType = new TypeToken<List<TranslationDataEntry>>() {}.getType();
 
-        try (FileReader reader = new FileReader(configFile, StandardCharSets.UTF_8)) {
+        try (FileReader reader = new FileReader(configFile, StandardCharsets.UTF_8)) {
             return gson.fromJson(reader, translationDataType);
         } catch (IOException e) {
             GuessTheUtils.LOGGER.error(e.getMessage());


### PR DESCRIPTION
force charset UTF8 for some operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured downloaded files are decoded with UTF-8 so content (including special and non-ASCII characters) displays consistently across platforms.
  * Ensured translation data files are read using UTF-8 to prevent mis‑rendered text and maintain consistent localization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->